### PR TITLE
chore: ensure secure jekyll version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source 'https://rubygems.org'
 
-# Use a recent github-pages release that pulls in a secure Active Support
+# Use a recent github-pages release that pulls in a secure Jekyll
 gem 'github-pages', '~> 232'
+
+# Explicitly require a safe Jekyll version
+gem 'jekyll', '>= 3.7.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages (~> 232)
+  jekyll (>= 3.7.4)
 
 BUNDLED WITH
    2.4.19


### PR DESCRIPTION
## Summary
- ensure `jekyll` gem is explicitly required at `>= 3.7.4`
- run `bundle update` to refresh dependencies
- rebuild site with `bundle exec jekyll build`

## Testing
- `bundle update`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_b_68c4975fc4948321aaf20dc5894a1b0f