### PR TITLE
Add explicit kramdown dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gem 'github-pages', '~> 232'
 
 # Explicitly require a safe Jekyll version
 gem 'jekyll', '>= 3.7.4'
+gem 'kramdown', '>= 2.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,6 +279,7 @@ PLATFORMS
 DEPENDENCIES
   github-pages (~> 232)
   jekyll (>= 3.7.4)
+  kramdown (>= 2.3.0)
 
 BUNDLED WITH
    2.4.19


### PR DESCRIPTION
## Summary
- explicitly require kramdown >= 2.3.0 to address CVE and ensure modern parser
- update bundled gems by running `bundle update kramdown`

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_68c6e9ace154832191ed344bba60d1c7