### PR TITLE
Declare Nokogiri dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ gem 'github-pages', '~> 232'
 # Explicitly require a safe Jekyll version
 gem 'jekyll', '>= 3.7.4'
 gem 'kramdown', '>= 2.3.0'
+# Explicitly require a safe Nokogiri version
+gem 'nokogiri', '>= 1.13.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,6 +280,7 @@ DEPENDENCIES
   github-pages (~> 232)
   jekyll (>= 3.7.4)
   kramdown (>= 2.3.0)
+  nokogiri (>= 1.13.0)
 
 BUNDLED WITH
    2.4.19


### PR DESCRIPTION
## Summary
- explicitly require nokogiri >= 1.13.0
- update lockfile via `bundle update nokogiri`

## Testing
- `bundle update nokogiri`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_68c6efebe5248321a592fea14f9d7212